### PR TITLE
fix(policy): delete old policy version before updating if needed

### DIFF
--- a/aws/aws_test.go
+++ b/aws/aws_test.go
@@ -6,9 +6,11 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-var validPolicy = api.NewPolicy("name", "testns", []api.StatementSpec{
-	{Resource: "arn:aws:s3:::my_corporate_bucket/exampleobject.png", Action: []string{"an:action"}},
-})
+var (
+	validPolicy = api.NewPolicy("name", "testns", []api.StatementSpec{
+		{Resource: "arn:aws:s3:::my_corporate_bucket/exampleobject.png", Action: []string{"an:action"}},
+	})
+)
 
 var _ = Describe("policy", func() {
 	It("given a valid policy", func() {
@@ -25,6 +27,14 @@ var _ = Describe("policy", func() {
 		policyARN, err := awsmngr.GetPolicyARN(validPolicy.PathPrefix(clusterName), validPolicy.AwsName(clusterName))
 		Expect(err).NotTo(HaveOccurred())
 		Expect(policyARN).NotTo(BeEmpty())
+
+		By("creating new policy versions 5 times")
+		validPolicy.Spec.ARN = policyARN
+
+		for i := 0; i < 5; i++ {
+			err = awsmngr.UpdatePolicy(*validPolicy)
+			Expect(err).ToNot(HaveOccurred())
+		}
 
 		By("deleting it")
 		Expect(policyARN).NotTo(BeEmpty())


### PR DESCRIPTION
A managed AWS policy can have a maximum of 5 policy versions. When a new version is created, the API returns an error.
Because of this, the irsa-operator currently can't update a policy more than 4 itmes.
This change adds a check that we can create a new version, and deletes the oldest non-default version otherwise.